### PR TITLE
fix(auth): resume onboarding for users who abandoned registration

### DIFF
--- a/src/components/layout/ProtectedRoute.jsx
+++ b/src/components/layout/ProtectedRoute.jsx
@@ -2,10 +2,14 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
 export default function ProtectedRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, onboardingCompleted } = useAuth();
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (!onboardingCompleted) {
+    return <Navigate to="/onboarding" replace />;
   }
 
   return <Outlet />;

--- a/src/components/ui/Toaster/toast.css
+++ b/src/components/ui/Toaster/toast.css
@@ -6,7 +6,7 @@
 
 .codemio-toaster {
   --font-family: var(--font-sans);
-  --width: 400px;
+  --width: 460px;
 }
 
 @media (max-width: 640px) {
@@ -18,14 +18,14 @@
 /* ===== Base toast card ===== */
 .codemio-toaster [data-sonner-toast] {
   font-family: var(--font-sans);
-  font-size: 0.9375rem;
+  font-size: 1rem;
   line-height: 1.5;
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
   background: var(--color-bg);
   color: var(--color-text);
-  padding: 18px 20px;
-  gap: 14px;
+  padding: 20px 24px;
+  gap: 16px;
   align-items: flex-start;
   box-shadow:
     0 16px 40px -10px rgba(30, 58, 95, 0.22),
@@ -56,7 +56,7 @@
 
 .codemio-toaster [data-sonner-toast] [data-title] {
   font-weight: 700;
-  font-size: 0.9375rem;
+  font-size: 1rem;
   line-height: 1.4;
   color: var(--color-text);
   letter-spacing: -0.005em;
@@ -64,15 +64,15 @@
 }
 
 .codemio-toaster [data-sonner-toast] [data-description] {
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: var(--color-text-light);
 }
 
 /* ===== Icon chip ===== */
 .codemio-toaster [data-sonner-toast] [data-icon] {
-  width: 34px;
-  height: 34px;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
@@ -82,8 +82,8 @@
 }
 
 .codemio-toaster [data-sonner-toast] [data-icon] svg {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
 }
 
 /* ===== Close button ===== */
@@ -92,10 +92,10 @@
   border: 1px solid var(--color-border);
   color: var(--color-text-light);
   border-radius: var(--radius-full);
-  width: 24px;
-  height: 24px;
-  top: 10px;
-  right: 10px;
+  width: 28px;
+  height: 28px;
+  top: 12px;
+  right: 12px;
   transition: color var(--transition-fast), background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
 }
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -109,11 +109,13 @@ export function AuthProvider({ children }) {
 
   const user = authState?.usuario ?? null;
   const isAuthenticated = !!authState?.access_token;
+  const onboardingCompleted = user?.onboarding_completed === true;
 
   const value = useMemo(
     () => ({
       user,
       isAuthenticated,
+      onboardingCompleted,
       loginAuth,
       logout,
       clearAuth,
@@ -128,7 +130,7 @@ export function AuthProvider({ children }) {
     // only their captured closures over refs/setters matter; re-memoizing on state changes is
     // cheap and keeps the value object stable for the current snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [user, isAuthenticated],
+    [user, isAuthenticated, onboardingCompleted],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/modules/auth/pages/LoginPage.jsx
+++ b/src/modules/auth/pages/LoginPage.jsx
@@ -58,7 +58,8 @@ export default function LoginPage() {
     try {
       const data = await login(form);
       loginAuth(data);
-      navigate('/dashboard');
+      const completed = data?.usuario?.onboarding_completed === true;
+      navigate(completed ? '/dashboard' : '/onboarding', { replace: true });
     } catch (err) {
       const msg =
         err.response?.data?.detail ||

--- a/src/modules/auth/pages/OnboardingPage.jsx
+++ b/src/modules/auth/pages/OnboardingPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../context/AuthContext';
 import { completeProfile } from '../services/onboardingService';
 import {
   sanitizePlainText,
@@ -30,11 +31,20 @@ const INITIAL_TOUCHED = { nombre: false, edad: false, perfil_github: false };
 
 export default function OnboardingPage() {
   const navigate = useNavigate();
+  const { isAuthenticated, onboardingCompleted, setUser } = useAuth();
   const [form, setForm] = useState(INITIAL_FORM);
   const [errors, setErrors] = useState(INITIAL_ERRORS);
   const [touched, setTouched] = useState(INITIAL_TOUCHED);
   const [serverError, setServerError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (onboardingCompleted) {
+    return <Navigate to="/dashboard" replace />;
+  }
 
   function handleChange(e) {
     const { name, value } = e.target;
@@ -68,12 +78,12 @@ export default function OnboardingPage() {
     setServerError('');
 
     try {
-      await completeProfile({
+      const updatedUser = await completeProfile({
         nombre: sanitizePlainText(form.nombre),
         edad: Number(form.edad),
         perfil_github: sanitizePlainText(form.perfil_github) || null,
       });
-      // TODO (rama de integración): actualizar AuthContext con `onboarding_completed: true`
+      setUser(updatedUser);
       navigate('/dashboard', { replace: true });
     } catch (err) {
       const msg =


### PR DESCRIPTION
## 📋 Información del Pull Request

### 🏷️ Versión y Ambiente

- **Ambiente afectado:**
  - [x] Desarrollo
- **Rama base:** `develop`
- **Rama feature:** `feature/FE-AUTH-07`

---

### 📝 Descripción

**¿Qué hace este PR?**

Arregla el flujo de onboarding para usuarios que completaron su registro (verificaron correo + crearon contraseña) pero abandonaron la pantalla de onboarding antes de guardar su perfil. Ahora el sistema detecta el estado incompleto al iniciar sesión y redirige automáticamente a `/onboarding` en vez de soltarles el dashboard con el perfil vacío. Además pule el sistema de toasts.

**Cambios concretos:**

- `AuthContext` expone `onboardingCompleted` derivado de `usuario.onboarding_completed` (el backend ya lo manda en el response de `POST /auth/login/`).
- `LoginPage` lee el flag después del login y redirige a `/onboarding` o `/dashboard` según corresponda.
- `ProtectedRoute` bloquea el acceso al dashboard para usuarios autenticados con onboarding incompleto y los manda a `/onboarding`.
- `OnboardingPage` redirige a `/login` si no hay sesión y a `/dashboard` si el onboarding ya está completo (evita el loop). Después de `PATCH /users/me/` llama `setUser(updatedUser)` para refrescar el contexto.
- `toast.css`: ancho 400→460 px, padding 18/20→20/24 px, título 15→16 px, descripción 13→14 px, ícono 34→38 px. Los toasts dejan de verse apretados en la esquina superior derecha.

**¿Por qué es necesario este cambio?**

Hoy, si un usuario cierra la pestaña en el paso de onboarding y vuelve más tarde:
- Reintentar registro falla con "El correo ya fue verificado" (porque Cognito ya lo confirmó).
- Intentar login sí funciona pero cae en `/dashboard` con el perfil vacío, y el usuario queda atorado.

Con este fix, sin necesidad de un endpoint de status adicional, el frontend lee el flag que el backend ya expone y decide correctamente a dónde llevar al usuario.

**¿Qué problema resuelve?**

- Usuarios que abandonan el onboarding quedaban sin un camino claro para retomarlo.
- El dashboard mostraba perfil vacío a usuarios con onboarding pendiente.
- Los toasts se veían chicos y apretados.

---

### 🔄 Pasos para Probar

**Flujo principal — onboarding resume:**
1. Registrar una cuenta nueva (correo + OTP + contraseña) y detenerse en la pantalla de onboarding **sin** enviar el formulario.
2. Cerrar la pestaña / recargar la app.
3. Ir a `/login` e iniciar sesión con esas credenciales.
4. **Esperado:** caer directamente en `/onboarding` (no en `/dashboard`).
5. Completar el perfil y enviar.
6. **Esperado:** caer en `/dashboard` con los datos del usuario ya visibles.

**Flujo de regreso — cuenta ya completa:**
1. Hacer logout y volver a iniciar sesión con la misma cuenta.
2. **Esperado:** caer directamente en `/dashboard`. Si se navega manualmente a `/onboarding`, redirige a `/dashboard`.

**Guard de ruta:**
1. Con un usuario autenticado pero onboarding incompleto, navegar manualmente a `/dashboard` o `/projects`.
2. **Esperado:** redirige a `/onboarding`.

**Acceso sin sesión a onboarding:**
1. Con sesión cerrada, navegar a `/onboarding` manualmente.
2. **Esperado:** redirige a `/login`.

**Toasts:**
1. Disparar cualquier toast (success/error/warning/info) en login, registro, proyectos, etc.
2. **Esperado:** tarjetas más anchas (460 px), más aire, tipografía más legible.

**Comandos:**
```bash
npm run dev
npm run lint
npm run build
```

---

### 🎫 Issue Relacionado

- **Issue:** FE-AUTH-07 (onboarding resume + toast polish)

---

### ℹ️ Información Adicional

#### 🔧 Cambios Técnicos

- **Archivos modificados:**
  - `src/context/AuthContext.jsx`
  - `src/modules/auth/pages/LoginPage.jsx`
  - `src/modules/auth/pages/OnboardingPage.jsx`
  - `src/components/layout/ProtectedRoute.jsx`
  - `src/components/ui/Toaster/toast.css`

- **Nuevas dependencias:** [x] No
- **Variables de entorno:** [x] No requiere
- **Cambios en configuración:** [x] No requiere

#### 🧪 Testing

- [x] Linting pasa sin errores (en archivos fuente)
- [x] Build exitoso
- [ ] Probado manualmente en navegadores — pendiente (ver "Pasos para Probar")

**Navegadores probados:**
- [ ] Chrome — pendiente QA manual
- [ ] Edge — pendiente QA manual

#### 🎯 Checklist de Calidad

- [x] Conventional Commits
- [x] Self-review
- [x] Sin warnings nuevos
- [x] No rompe funcionalidad existente

#### 🎨 Checklist UI/UX

- [x] Feedback visual apropiado (toasts más legibles)
- [x] Estados de redirect manejados (sin flashes de dashboard vacío)
- [x] Consistente con tokens del design system (`variables.css`)

#### 🔒 Seguridad

- [x] No se exponen secretos
- [x] `ProtectedRoute` sigue validando `isAuthenticated` antes de cualquier otra cosa

---

### 🚀 Deployment

- [x] Listo para merge a develop

**Notas de deployment:**
Este PR depende lógicamente del refactor de `httpClient` (PR #32). Al momento de redactar este PR, ese refactor ya está en `develop`, así que no hay bloqueo.

---

**Tipo de cambio:**
- [x] 🐛 Bug fix (onboarding resume)
- [x] 🎨 Mejora de UI/UX (toasts)